### PR TITLE
Fixed an access level to subscriptions

### DIFF
--- a/cmd/gen/main.go
+++ b/cmd/gen/main.go
@@ -10,28 +10,29 @@ import (
 )
 
 type data struct {
-	FuncName, Args, Format, Type, Channel string
+	FuncName, Args, Format, Type, AccessLevel, Channel string
 }
 
 var subscriptions = map[string]struct {
 	funcName, notificationType string
+	isPrivate                  bool
 }{
-	"book.{instrument_name}.{group}.{depth}.{interval}": {"BookGroup", "BookNotification"},
-	"book.{instrument_name}.{interval}":                 {"BookInterval", "BookNotificationRaw"},
-	"deribit_price_index.{index_name}":                  {"DeribitPriceIndex", "DeribitPriceIndexNotification"},
-	"deribit_price_ranking.{index_name}":                {"DeribitPriceRanking", "DeribitPriceRankingNotification"},
-	"estimated_expiration_price.{index_name}":           {"EstimatedExpirationPrice", "EstimatedExpirationPriceNotification"},
-	"markprice.options.{index_name}":                    {"MarkPriceOptions", "MarkpriceOptionsNotification"},
-	"perpetual.{instrument_name}.{interval}":            {"Perpetual", "PerpetualNotification"},
-	"quote.{instrument_name}":                           {"Quote", "QuoteNotification"},
-	"ticker.{instrument_name}.{interval}":               {"Ticker", "TickerNotification"},
-	"trades.{instrument_name}.{interval}":               {"Trades", "PublicTrade"},
-	"user.orders.{instrument_name}.{interval}":          {"UserOrdersInstrumentName", "Order"},
-	"user.orders.{kind}.{currency}.{interval}":          {"UserOrdersKind", "Order"},
-	"user.portfolio.{currency}":                         {"UserPortfolio", "UserPortfolioNotification"},
-	"user.trades.{instrument_name}.{interval}":          {"UserTradesInstrument", "UserTrade"},
-	"user.trades.{kind}.{currency}.{interval}":          {"UserTradesKind", "UserTrade"},
-	"announcements":                                     {"Announcements", "AnnouncementNotification"},
+	"book.{instrument_name}.{group}.{depth}.{interval}": {"BookGroup", "BookNotification", false},
+	"book.{instrument_name}.{interval}":                 {"BookInterval", "BookNotificationRaw", false},
+	"deribit_price_index.{index_name}":                  {"DeribitPriceIndex", "DeribitPriceIndexNotification", false},
+	"deribit_price_ranking.{index_name}":                {"DeribitPriceRanking", "DeribitPriceRankingNotification", false},
+	"estimated_expiration_price.{index_name}":           {"EstimatedExpirationPrice", "EstimatedExpirationPriceNotification", false},
+	"markprice.options.{index_name}":                    {"MarkPriceOptions", "MarkpriceOptionsNotification", false},
+	"perpetual.{instrument_name}.{interval}":            {"Perpetual", "PerpetualNotification", false},
+	"quote.{instrument_name}":                           {"Quote", "QuoteNotification", false},
+	"ticker.{instrument_name}.{interval}":               {"Ticker", "TickerNotification", false},
+	"trades.{instrument_name}.{interval}":               {"Trades", "PublicTrade", false},
+	"user.orders.{instrument_name}.{interval}":          {"UserOrdersInstrumentName", "Order", true},
+	"user.orders.{kind}.{currency}.{interval}":          {"UserOrdersKind", "Order", true},
+	"user.portfolio.{currency}":                         {"UserPortfolio", "UserPortfolioNotification", true},
+	"user.trades.{instrument_name}.{interval}":          {"UserTradesInstrument", "UserTrade", true},
+	"user.trades.{kind}.{currency}.{interval}":          {"UserTradesKind", "UserTrade", true},
+	"announcements":                                     {"Announcements", "AnnouncementNotification", true},
 }
 
 func main() {
@@ -44,6 +45,10 @@ func main() {
 		d.Channel = c
 		d.FuncName = "Subscribe" + params.funcName
 		d.Type = params.notificationType
+		d.AccessLevel = "Public"
+		if params.isPrivate {
+			d.AccessLevel = "Private"
+		}
 		re := regexp.MustCompile(`\{(.*?)\}`)
 		match := re.FindAllStringSubmatch(c, -1)
 		if len(match) > 0 {
@@ -75,7 +80,7 @@ func (e *Exchange) {{.FuncName}}({{.Args}}{{if .Args}} string{{end}}) (chan *mod
 	e.subscriptions[chans[0]] = sub
 
     client := e.Client()
-	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
+	if _, err := client.Get{{.AccessLevel}}Subscribe(&operations.Get{{.AccessLevel}}SubscribeParams{Channels: chans}); err != nil {
 		delete(e.subscriptions, chans[0])
 		return nil, fmt.Errorf("error subscribing to channel: %s", err)
 	}


### PR DESCRIPTION
The issue: in cmd/gen/main.go the subscriptionTemplate was hard coded only with public access to any subscription, but some of them has a private access.

Solution: Added AccessLevel to distinguish public and private subscriptions.

Also on master branch: a decode fails to most of subscriptions with error:

RPC Error: error decoding notification: a map, expected a slice
the error is coming from here:

if err := mapstructure.Decode(n.Params.Data, &ret); err != nil {
					e.errors <- fmt.Errorf("error decoding notification: %s", err)
				}
and it occurs, because n.Params.Data is json.RawMessage, i.e. slice of byte. And even if I unmarshal json.RawMessage to map[string]interface{} before, mapstructure skips some fields while decoding.

But anyway, your initial template had the std lib json.Unmarshal which is working fine.